### PR TITLE
Add symlink from u-squery to usquery

### DIFF
--- a/bin/usquery
+++ b/bin/usquery
@@ -1,0 +1,1 @@
+u-squery


### PR DESCRIPTION
image-status references usquery which does not exist.
This commit adds a new symlink from u-squery to usquery.