### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ entitlted 'Simplestreams Tutorial'
 The session was executed on a fresh 14.04 Ubuntu cloud instance.
 
 The only prep done ahead of time was:
- sudo apt-get update && sudo apt-get install --assume-yes git bzr
+ sudo apt-get update && sudo apt-get install --assume-yes git bzr ubuntu-cloudimage-keyring
  git clone https://github.com/smoser/talk-simplestreams.git talk
  bzr branch lp:simplestreams  talk/simplestreams
  export PATH=$PWD/talk/bin:$PWD/talk/simplestreams/tools:$PATH


### PR DESCRIPTION
Added ubuntu-cloudimage-keyring to the list of needed packages (image-status otherwise fails to run).