### PR TITLE
image-status strict confinement snap

### DIFF
--- a/bin/image-status
+++ b/bin/image-status
@@ -201,7 +201,7 @@ main() {
 
     $defaults && filters=( "${def_filters[@]}" "${filters[@]}" )
 
-    cmd=( usquery $maxarg "$fmt"
+    cmd=( u-stool $maxarg "$fmt"
           "$uwhere" "${pt[@]}" "${filters[@]}" )
     debug 1 "${cmd[*]}"
 

--- a/bin/u-stool
+++ b/bin/u-stool
@@ -46,7 +46,7 @@ sdata=(
 SPROG="sstream-query"
 case "$0" in
    *smirror) SPROG="sstream-mirror";;
-   *squery) SPROG="sstream-query";;
+   *squery|*\-stool) SPROG="sstream-query";;
    *)
       echo "Expect to be called usmirror or usquery, not ${0##*/}";
       exit 1;;

--- a/bin/u-stool
+++ b/bin/u-stool
@@ -2,6 +2,10 @@
 #
 # https://github.com/smoser/talk-simplestreams/blob/master/bin/u-stool
 
+# If this tool is running in a snap we should update the path to use when
+# querying the ubuntu-cloudimage-keyring
+SNAP_PATH=${SNAP:-""}
+
 declare -A sdata
 CIU_COM="http://cloud-images.ubuntu.com"
 CIU_COM_R="$CIU_COM/releases"
@@ -93,7 +97,7 @@ done
 keyopt=""
 case "$url" in
    *.json) :;;
-   *) keyopt="--keyring=/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg";;
+   *) keyopt="--keyring=${SNAP_PATH}/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg";;
 esac
 
 cmd=( "$SPROG" ${keyopt:+"${keyopt}"} "${opts[@]}" "${args[@]}" )

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,58 @@
+name: image-status
+version: '0.1'
+summary: Helpful utility to check the status of Ubuntu cloud images.
+description: |
+  Helpful utility to check the status of Ubuntu cloud images.
+
+  A wrapper around sstream-query which queries the Ubuntu's simplestreams feeds
+  (http://cloud-images.ubuntu.com/daily/streams/v1/ and
+  http://cloud-images.ubuntu.com/releases/streams/v1/).
+
+  See https://github.com/smoser/talk-simplestreams/ for source.
+
+  Usage:
+  image-status --help # to see all available options
+
+  image-status cloud-release xenial # to see most recent Ubuntu Xenial release images on http://cloud-images.ubuntu.com/
+  image-status cloud-daily xenial # to see most recent Ubuntu Xenial daily images on http://cloud-images.ubuntu.com/
+
+  image-status gce-release xenial # to see most recent Ubuntu Xenial release images on GCE
+  image-status gce-daily xenial # to see most recent Ubuntu Xenial daily images on GCE
+
+  image-status ec2-release xenial # to see most recent Ubuntu Xenial release AMIs on EC2
+  image-status ec2-daily xenial # to see most recent Ubuntu Xenial daily AMIs on EC2
+
+  image-status azure-release xenial # to see most recent Ubuntu Xenial release images on Azure
+  image-status azure-daily xenial # to see most recent Ubuntu Xenial daily images on Azure
+
+  image-status maas-release xenial # to see most recent Ubuntu Xenial release images for maas V2
+  image-status maas-daily xenial # to see most recent Ubuntu Xenial daily images for maas V2
+
+  image-status maas3-release xenial # to see most recent Ubuntu Xenial release images for maas V3
+  image-status maas3-daily xenial # to see most recent Ubuntu Xenial daily images for maas V3
+
+grade: stable
+confinement: strict
+
+apps:
+  image-status:
+    command: image-status
+    plugs:
+      - network
+
+parts:
+  image-status:
+    plugin: dump
+    source: bin
+    prepare: |
+      chmod +x image-status
+      chmod +x u-stool
+    stage-packages:
+      - ubuntu-cloudimage-keyring
+      - simplestreams
+      - distro-info
+      - bsdmainutils
+      - gpgv
+    organize:
+      image-status: usr/bin/image-status
+      u-stool: usr/bin/u-stool

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: image-status
+name: image-status-philroche
 version: '0.1'
 summary: Helpful utility to check the status of Ubuntu cloud images.
 description: |


### PR DESCRIPTION
I have been using `image-status` more and more and to make it easier to install I have created snap/snapcraft.yaml which builds a strict confinement snap for image-status.

You can test this by installing the temporarily named "image-status-philroche"

`sudo snap install image-status-philroche`

and test using 

`/snap/bin/image-status-philroche.image-status cloud-daily xenial`

Feel free to change snap name and register repo with https://build.snapcraft.io/ or I can do this if you like.