### PR TITLE
Streams for minimal cloud images now exist

### DIFF
--- a/bin/image-status
+++ b/bin/image-status
@@ -12,7 +12,7 @@ dump_supported() {
     cat <<EOF
 description    | names
 Azure cloud    | azure   azure-daily   azure-release
-cloud images   | cloud   cloud-daily   cloud-release
+cloud images   | cloud   cloud-daily   cloud-release cloud-daily-minimal
 AWS EC2        | ec2     ec2-daily     ec2-release
 Google Compute | gce     gce-daily     gce-release
 MAAS v2        | maas    maas-daily    maas-release
@@ -122,6 +122,9 @@ main() {
         cloud-release)
             mtype="cloud"
             uwhere="uc-dl";;
+        cloud-daily-minimal|cloud-minimal)
+            mtype="cloud"
+            uwhere="uc-dl-daily-minimal";;
         ec2-daily|ec2)
             uwhere="uc-aws-daily"
             mtype="ec2";;

--- a/bin/u-stool
+++ b/bin/u-stool
@@ -28,6 +28,7 @@ sdata=(
   [uc-dl]="$CIU_COM_R/streams/v1/com.ubuntu.cloud:released:download.sjson"
   [uc-daily]="$CIU_COM/daily/streams/v1/index.sjson"
   [uc-dl-daily]="$CIU_COM/daily/streams/v1/com.ubuntu.cloud:daily:download.sjson"
+  [uc-dl-daily-minimal]="$CIU_COM/minimal/daily/streams/v1/com.ubuntu.cloud.daily:download.sjson"
 
   [maas-release]="$MAAS_v2/releases/streams/v1/index.sjson"
   [maas-daily]="$MAAS_v2/daily/streams/v1/index.sjson"


### PR DESCRIPTION
Streams for minimal cloud images now exist

This MP add the cloud-minimal and the cloud-daily-minimal image type to image-status

Once release streams exist for minimal images I will create a new PR
