### PR TITLE
Add support for querying MAAS centos images

### DIFF
--- a/bin/image-status
+++ b/bin/image-status
@@ -11,12 +11,13 @@ fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
 dump_supported() {
     cat <<EOF
 description    | names
-Azure cloud    | azure   azure-daily   azure-release
-cloud images   | cloud   cloud-daily   cloud-release    cloud-daily-minimal     cloud-release-minimal
-AWS EC2        | ec2     ec2-daily     ec2-release      ec2-daily-minimal       ec2-release-minimal
-Google Compute | gce     gce-daily     gce-release      gce-daily-minimal       gce-release-minimal
-MAAS v2        | maas    maas-daily    maas-release
-MAAS v3        | maas3   maas3-daily   maas3-release
+Azure cloud    | azure   azure-daily          azure-release
+cloud images   | cloud   cloud-daily          cloud-release    cloud-daily-minimal     cloud-release-minimal
+AWS EC2        | ec2     ec2-daily            ec2-release      ec2-daily-minimal       ec2-release-minimal
+Google Compute | gce     gce-daily            gce-release      gce-daily-minimal       gce-release-minimal
+MAAS v2        | maas    maas-daily           maas-release
+MAAS v3        | maas3   maas3-daily          maas3-release
+MAAS v3 Centos | maas3c  maas3-daily-centos   maas3-release-centos
 EOF
 }
 
@@ -97,6 +98,7 @@ main() {
     local tab=$'\t'
     local maas_fmt="%(release)-7s$tab%(arch)s/%(subarch)s$tab%(version_name)s$tab%(item_name)s"
     local maas3_fmt="%(release)-7s$tab%(arch)s/%(subarch)s/%(kflavor)s$tab%(version_name)s$tab%(item_name)s"
+    local maas3c_fmt="%(release)-7s$tab%(arch)s/%(subarch)s$tab%(version_name)s$tab%(item_name)s"
     local img_fmt="%(release)-7s$tab%(arch)s$tab%(version_name)s$tab%(item_name)s"
     local ec2_fmt="%(release)-7s$tab%(version_name)-10s$tab%(crsn)-14s$tab%(root_store)-8s$tab%(virt)-3s$tab%(id)s"
     local azure_fmt="%(release)-7s$tab%(version_name)-10s$tab%(crsn)-14s$tab%(id)s"
@@ -113,6 +115,9 @@ main() {
         maas3|maas3-daily)
             mtype="maas3"
             uwhere="maas3-eph-daily";;
+        maas3c|maas3-daily-centos)
+            mtype="maas3c"
+            uwhere="maas3-daily-centos";;
         maas-release)
             mtype="maas"
             uwhere="maas-eph-rel";;
@@ -172,6 +177,10 @@ main() {
         maas3)
             def_filters=( "${def_filters[@]}" "ftype=squashfs" )
             fmt="$maas3_fmt";;
+        maas3c)
+            RELEASES=( "centos66" "centos70" )
+            def_filters=( "${def_filters[@]}" "ftype=root-tgz" )
+            fmt="$maas3c_fmt";;
         cloud)
             def_filters=( "${def_filters[@]}" "ftype=disk1.img" )
             fmt="$img_fmt";;
@@ -212,7 +221,7 @@ main() {
     done
     if [ -z "$reltok" ]; then
         local m=""
-        for r in $(ubuntu-distro-info --supported); do
+        for r in ${RELEASES[@]}; do
             m="${m:+${m}|}$r"
         done
         def_filters[${#def_filters[@]}]="release~$m"

--- a/bin/u-stool
+++ b/bin/u-stool
@@ -42,6 +42,7 @@ sdata=(
 
   [maas3-daily]="$MAAS_v3/daily/streams/v1/index.sjson"
   [maas3-eph-daily]="$MAAS_v3/daily/streams/v1/com.ubuntu.maas:daily:v3:download.sjson"
+  [maas3-daily-centos]="$MAAS_v3/daily/streams/v1/com.ubuntu.maas:daily:centos-bases-download.json"
 
   [cirros]="http://download.cirros-cloud.net/streams/v1/index.json"
   [cstack]="$CST/simplestreams/data/streams/v1/index.json"


### PR DESCRIPTION
Add 'maas3c' as codename for querying Centos images.

% image-status maas3c
centos66  amd64/generic  20180801_01  root-image.gz
centos70  amd64/generic  20180801_01  root-image.gz