### PR TITLE
Update maas3 daily stream url, add maas3-release.

### DIFF
--- a/bin/image-status
+++ b/bin/image-status
@@ -19,7 +19,7 @@ cloud images   | cloud   cloud-daily          cloud-release    cloud-daily-minim
 AWS EC2        | ec2     ec2-daily            ec2-release      ec2-daily-minimal       ec2-release-minimal
 Google Compute | gce     gce-daily            gce-release      gce-daily-minimal       gce-release-minimal
 MAAS v2        | maas    maas-daily           maas-release
-MAAS v3        | maas3   maas3-daily
+MAAS v3        | maas3   maas3-daily          maas3-release
 MAAS v3 Centos | maas3c  maas3-daily-centos
 EOF
 }
@@ -129,6 +129,9 @@ main() {
         maas3|maas3-daily)
             mtype="maas3"
             uwhere="maas3-eph-daily";;
+        maas3-release)
+            mtype="maas3"
+            uwhere="maas3-eph-stable";;
         maas3c|maas3-daily-centos)
             mtype="maas3c"
             uwhere="maas3-daily-centos";;

--- a/bin/u-stool
+++ b/bin/u-stool
@@ -41,7 +41,8 @@ sdata=(
   [maas-eph-daily]="$MAAS_v2/daily/streams/v1/com.ubuntu.maas:daily:v2:download.sjson"
 
   [maas3-daily]="$MAAS_v3/daily/streams/v1/index.sjson"
-  [maas3-eph-daily]="$MAAS_v3/daily/streams/v1/com.ubuntu.maas:daily:v3:download.sjson"
+  [maas3-eph-daily]="$MAAS_v3/candidate/streams/v1/com.ubuntu.maas:candidate:v3:download.sjson"
+  [maas3-eph-stable]="$MAAS_v3/stable/streams/v1/com.ubuntu.maas:stable:v3:download.sjson"
   [maas3-daily-centos]="$MAAS_v3/daily/streams/v1/com.ubuntu.maas:daily:centos-bases-download.json"
 
   [cirros]="http://download.cirros-cloud.net/streams/v1/index.json"


### PR DESCRIPTION
The maas3 daily stream url changed, and these tools were broken
as a result.  The bug really resided in the tools direct usage
of the maas images file rather than going through index.sjson.